### PR TITLE
Typo

### DIFF
--- a/namedef.dtx
+++ b/namedef.dtx
@@ -452,7 +452,7 @@
 % However, for readability, the delimiter can be changed to something
 % else:
 %   \named\def\hello[#[who]]{Hello #[who]!}
-% \begin{example}[label=Argument delimited by \texttt{[} and \texttt{]},
+% \begin{example}[label=Argument delimited by \texttt{\string|} and \texttt{\string|},
 %   commandchars=/<>,firstnumber=0]
 %   \NamedDelim{|}{|}
 %         \def\hello[#1]{Hello #1!}


### PR DESCRIPTION
Change the label of example containing `\NamedDelim{|}{|}` from
```tex
Argument delimited by \texttt{[} and \texttt{]}
```
to
```tex
Argument delimited by \texttt{\string|} and \texttt{\string|}
```